### PR TITLE
Sizing options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,9 +100,13 @@ this section if you aren't using any.
 
 Input a diagram in a kroki macro and pass the diagram type as the first argument.
 
+### Diagram Type
+
 * Choose from this list of [supported diagram types](https://kroki.io/#support)
   \+ `diagramsnet`
 * Enter the diagram type as alpha-numeric characters
+
+### Diagram Options
 
 Optionally, you can add [diagram options](https://docs.kroki.io/kroki/setup/diagram-options/)
 to change how the diagram is displayed.
@@ -111,6 +115,16 @@ to change how the diagram is displayed.
 * If a key or a value has more than one word, replace the spaces by a dash and
 keep it lowercase (_kebab-case_)
 * You can add as many as you want
+
+### Diagram Size
+
+In some situations, diagrams may be too large. You can limit their size with
+these options:
+
+* `max_width`: Integer in pixels. The diagram will fill available space
+unless the screen is narrower than the provided value.
+* `max_height`: Integer in pixels. The diagram will fill the space up
+to that limit or until it reaches 100% width.
 
 ✅ Correct
 
@@ -132,6 +146,18 @@ keep it lowercase (_kebab-case_)
 }}
 
 {{kroki(mermaid, theme=dark, font-family=serif)
+...
+}}
+
+{{kroki(mermaid, max_width=500)
+...
+}}
+
+{{kroki(mermaid, max_height=500)
+...
+}}
+
+{{kroki(mermaid, theme=dark, max_width=500)
 ...
 }}
 ```
@@ -156,6 +182,18 @@ keep it lowercase (_kebab-case_)
 }}
 
 {{kroki(mermaid, fontFamily=serif)
+...
+}}
+
+{{kroki(mermaid, max-width=500px)
+...
+}}
+
+{{kroki(mermaid, max-width=500%)
+...
+}}
+
+{{kroki(mermaid, max-width=0)
 ...
 }}
 ```

--- a/src/app/helpers/redmine_kroki_helper.rb
+++ b/src/app/helpers/redmine_kroki_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+PLUGIN_OPTIONS = %i[max_width max_height].freeze
+
 # Utility functions for the Redmine-Kroki plugin
 module RedmineKrokiHelper
   require 'net/http'
@@ -40,7 +42,8 @@ end
 
 def add_diagram_options(request, options)
   options.each do |k, v|
-    request.add_field("Kroki-Diagram-Options-#{k.to_s.downcase.capitalize}", v)
+    request.add_field("Kroki-Diagram-Options-#{k.to_s.downcase.capitalize}", v) \
+      unless PLUGIN_OPTIONS.include?(k)
   end
 end
 

--- a/src/app/helpers/redmine_kroki_helper.rb
+++ b/src/app/helpers/redmine_kroki_helper.rb
@@ -62,24 +62,22 @@ def wrap_diagram(diagram, classes, options)
   "#{style_tag}<div class=\"#{classes}\" style=\"#{styles}\">#{diagram}</div>"
 end
 
-def css_value?(value)
-  css_units = %i[px %].freeze
-  regex = /\A\d+(#{css_units.join('|')})\z/
-  !!(value =~ regex)
+def only_digits?(value)
+  !!value.match?(/\A\d+\z/)
 end
 
 def convert_options_to_style(options)
   return '' if options.nil?
 
   plugin_options = options.select do |k, v|
-    PLUGIN_OPTIONS.include?(k) && css_value?(v)
+    PLUGIN_OPTIONS.include?(k) && only_digits?(v)
   end
 
   return '' if plugin_options.empty?
 
   style = ''.dup
   plugin_options.reduce(style) do |acc, (k, v)|
-    acc << "#{plugin_option_css_rule(k)}: #{v}; "
+    acc << "#{plugin_option_css_rule(k)}: #{v}px; "
   end
 
   style.strip

--- a/src/assets/stylesheets/redmine-kroki.css
+++ b/src/assets/stylesheets/redmine-kroki.css
@@ -1,8 +1,14 @@
 .kroki {
   display: block;
-  max-width: 100%;
-  max-height: 100%;
-  overflow: auto;
+  overflow: visible;
+}
+
+.kroki svg {
+  width: 100%;
+}
+
+.kroki.resized svg {
+  height: 100%;
 }
 
 .kroki.dark svg {

--- a/src/init.rb
+++ b/src/init.rb
@@ -32,7 +32,7 @@ Redmine::Plugin.register :redmine_kroki do
         Setting.plugin_redmine_kroki[:dark_themes],
         get_user_theme(User.current)
       )
-      res = wrap_diagram(diagram, css)
+      res = wrap_diagram(diagram, css, diagram_options)
 
       res.html_safe.force_encoding('UTF-8')
     end

--- a/src/test/redmine_kroki_helper.rb
+++ b/src/test/redmine_kroki_helper.rb
@@ -242,19 +242,19 @@ class RedmineKrokiHelperTest < ActionView::TestCase
   end
 
   test 'convert_options_to_style returns correct max-height' do
-    result = convert_options_to_style({ max_height: '1px' })
+    result = convert_options_to_style({ max_height: '1' })
 
     assert_equal('height: 1px;', result)
   end
 
   test 'convert_options_to_style returns correct max-width' do
-    result = convert_options_to_style({ max_width: '1px' })
+    result = convert_options_to_style({ max_width: '1' })
 
     assert_equal('max-width: 1px;', result)
   end
 
   test 'convert_options_to_style returns correct both max-height & max-width' do
-    result = convert_options_to_style({ max_height: '1px', max_width: '2px' })
+    result = convert_options_to_style({ max_height: '1', max_width: '2' })
 
     assert_equal('height: 1px; max-width: 2px;', result)
   end
@@ -271,24 +271,27 @@ class RedmineKrokiHelperTest < ActionView::TestCase
     assert_equal('', result)
   end
 
-  test 'css_value? with % returns true' do
-    assert_equal(true, css_value?('1%'))
+  test 'only_digits? with one digit returns true' do
+    assert_equal(true, only_digits?('1'))
   end
 
-  test 'css_value? with px returns true' do
-    assert_equal(true, css_value?('1px'))
+  test 'only_digits? with multi-digits returns true' do
+    assert_equal(true, only_digits?('123456'))
   end
 
-  test 'css_value? with multi-digit % returns true' do
-    assert_equal(true, css_value?('123456%'))
+  test 'only_digits? with % returns false' do
+    assert_equal(false, only_digits?('1%'))
   end
 
-  test 'css_value? with multi-digit px returns true' do
-    assert_equal(true, css_value?('123456px'))
+  test 'only_digits? with px returns false' do
+    assert_equal(false, only_digits?('1px'))
   end
 
-  test 'css_value? with both px and % returns false' do
-    assert_equal(false, css_value?('1%px'))
-    assert_equal(false, css_value?('1px%'))
+  test 'only_digits? with multi-digit % returns false' do
+    assert_equal(false, only_digits?('123456%'))
+  end
+
+  test 'only_digits? with multi-digit px returns false' do
+    assert_equal(false, only_digits?('123456px'))
   end
 end

--- a/src/test/redmine_kroki_helper.rb
+++ b/src/test/redmine_kroki_helper.rb
@@ -240,4 +240,55 @@ class RedmineKrokiHelperTest < ActionView::TestCase
 
     assert_nil(result)
   end
+
+  test 'convert_options_to_style returns correct max-height' do
+    result = convert_options_to_style({ max_height: '1px' })
+
+    assert_equal('height: 1px;', result)
+  end
+
+  test 'convert_options_to_style returns correct max-width' do
+    result = convert_options_to_style({ max_width: '1px' })
+
+    assert_equal('max-width: 1px;', result)
+  end
+
+  test 'convert_options_to_style returns correct both max-height & max-width' do
+    result = convert_options_to_style({ max_height: '1px', max_width: '2px' })
+
+    assert_equal('height: 1px; max-width: 2px;', result)
+  end
+
+  test 'convert_options_to_style with no options returns empty string' do
+    result = convert_options_to_style(nil)
+
+    assert_equal('', result)
+  end
+
+  test 'convert_options_to_style with diagram option returns empty string' do
+    result = convert_options_to_style({ key1: 'value1' })
+
+    assert_equal('', result)
+  end
+
+  test 'css_value? with % returns true' do
+    assert_equal(true, css_value?('1%'))
+  end
+
+  test 'css_value? with px returns true' do
+    assert_equal(true, css_value?('1px'))
+  end
+
+  test 'css_value? with multi-digit % returns true' do
+    assert_equal(true, css_value?('123456%'))
+  end
+
+  test 'css_value? with multi-digit px returns true' do
+    assert_equal(true, css_value?('123456px'))
+  end
+
+  test 'css_value? with both px and % returns false' do
+    assert_equal(false, css_value?('1%px'))
+    assert_equal(false, css_value?('1px%'))
+  end
 end

--- a/src/test/redmine_kroki_helper.rb
+++ b/src/test/redmine_kroki_helper.rb
@@ -218,6 +218,13 @@ class RedmineKrokiHelperTest < ActionView::TestCase
     assert_equal('value2', req['Kroki-Diagram-Options-Key2'])
   end
 
+  test 'add_diagram_options with plugin options does not append to request' do
+    req = Net::HTTP::Get.new('http://test.test')
+    add_diagram_options(req, { max_height: '1px', max_width: '1px' })
+    assert_nil(req['Kroki-Diagram-Options-Max_height'])
+    assert_nil(req['Kroki-Diagram-Options-Max_width'])
+  end
+
   test 'parse_macro_options returns correct values' do
     options = ['key1=value1', 'key2=value2']
 


### PR DESCRIPTION
Allows to limit the size of a diagram by passing `max_width` or `max_height` options in the macro.

For instance:

```md
{{kroki(mermaid, max_width=500)
...
}}
```

Will limit the width of the diagram to 500px.

## Commit Summary

- **feat: do not append plugin options to request**
- **feat: resize diagrams with diagram options**
- **fix: only accept px for diagram sizing**
- **doc: add diagram sizing options**
