### PR TITLE
Font Awesome support for Mermaid diagrams

### DIFF
--- a/src/app/helpers/redmine_kroki_helper.rb
+++ b/src/app/helpers/redmine_kroki_helper.rb
@@ -100,10 +100,10 @@ module RedmineKrokiHelper
   def generate_fa_css_tag(diagram)
     return ''.html_safe unless diagram.include?('<i class="fa')
 
-    stylesheet_link_tag getSettingOrDefault('fontawesome_css')
+    stylesheet_link_tag get_setting_or_default('fontawesome_css')
   end
 
-  def getSettingOrDefault(setting)
+  def get_setting_or_default(setting)
     Setting.plugin_redmine_kroki[:"#{setting}"] ||
              Redmine::Plugin.find(:redmine_kroki).settings[:default][setting]
   end

--- a/src/app/helpers/redmine_kroki_helper.rb
+++ b/src/app/helpers/redmine_kroki_helper.rb
@@ -100,10 +100,12 @@ module RedmineKrokiHelper
   def generate_fa_css_tag(diagram)
     return ''.html_safe unless diagram.include?('<i class="fa')
 
-    fa_url = Setting.plugin_redmine_kroki[:fontawesome_css] ||
-             Redmine::Plugin.find(:redmine_kroki).settings[:default]['fontawesome_css']
+    stylesheet_link_tag getSettingOrDefault('fontawesome_css')
+  end
 
-    stylesheet_link_tag fa_url
+  def getSettingOrDefault(setting)
+    Setting.plugin_redmine_kroki[:"#{setting}"] ||
+             Redmine::Plugin.find(:redmine_kroki).settings[:default][setting]
   end
 
   def only_digits?(value)

--- a/src/app/helpers/redmine_kroki_helper.rb
+++ b/src/app/helpers/redmine_kroki_helper.rb
@@ -26,9 +26,8 @@ module RedmineKrokiHelper
   end
 
   def wrap_diagram(diagram, classes, options, diagram_type = nil)
-    version = Redmine::Plugin.registered_plugins[:redmine_kroki].version
     style_tag = generate_css_tag('redmine-kroki')
-    style_tag = style_tag + embed_fonts(diagram_type)
+    style_tag += embed_fonts(diagram_type, diagram)
     styles = convert_options_to_style(options)
     classes = classes.dup << ' resized' unless styles.empty?
     classes = classes.dup << " #{diagram_type.downcase.delete(' -')}" if diagram_type
@@ -77,15 +76,23 @@ module RedmineKrokiHelper
     end
   end
 
-  def embed_fonts(diagram_type)
-    return '' unless diagram_type
+  def embed_fonts(diagram_type, diagram)
+    return ''.html_safe unless diagram_type
 
     case diagram_type.downcase
     when 'excalidraw'
       generate_css_tag('excalidraw')
+    when 'mermaid'
+      generate_fa_css_tag(diagram)
     else
       ''.html_safe
     end
+  end
+
+  def generate_fa_css_tag(_diagram)
+    fa_url = Setting.plugin_redmine_kroki[:fontawesome_css] ||
+             Redmine::Plugin.find(:redmine_kroki).settings[:default]['fontawesome_css']
+    stylesheet_link_tag fa_url
   end
 
   def only_digits?(value)
@@ -114,6 +121,6 @@ module RedmineKrokiHelper
   end
 
   def generate_css_tag(filename)
-    stylesheet_link_tag filename, plugin: "redmine_kroki"
+    stylesheet_link_tag filename, plugin: 'redmine_kroki'
   end
 end

--- a/src/app/helpers/redmine_kroki_helper.rb
+++ b/src/app/helpers/redmine_kroki_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../lib/mermaid_icon_patterns'
+
 PLUGIN_OPTIONS = %i[max_width max_height].freeze
 
 # Utility functions for the Redmine-Kroki plugin
@@ -69,9 +71,9 @@ module RedmineKrokiHelper
     when 'nomnoml'
       diagram_content.tr("\r", "\n")
     when 'mermaid'
-      # HACK: Kroki doesn't correctly size boxes with icons but no text
-      copyless_icon_regex = /([(\[])fa:([\w-]+)\s*([)\]])/
-      diagram_content.gsub(copyless_icon_regex, '\1&nbsp; fa:\2 &nbsp;\3')
+      MERMAID_SHAPE_ICON_PATTERNS.reduce(diagram_content) do |result, pattern|
+        result.gsub(pattern[:regex], pattern[:replacement])
+      end
     else
       diagram_content
     end

--- a/src/app/helpers/redmine_kroki_helper.rb
+++ b/src/app/helpers/redmine_kroki_helper.rb
@@ -63,10 +63,18 @@ module RedmineKrokiHelper
   end
 
   def sanitize_diagram(diagram_type, diagram_content)
-    return diagram_content.tr("\r", "\n") \
-      if diagram_type == 'nomnoml' && !diagram_content.nil?
+    return nil if diagram_content.nil?
 
-    diagram_content
+    case diagram_type.downcase
+    when 'nomnoml'
+      diagram_content.tr("\r", "\n")
+    when 'mermaid'
+      # HACK: Kroki doesn't correctly size boxes with icons but no text
+      copyless_icon_regex = /([(\[])fa:([\w-]+)\s*([)\]])/
+      diagram_content.gsub(copyless_icon_regex, '\1&nbsp; fa:\2 &nbsp;\3')
+    else
+      diagram_content
+    end
   end
 
   def add_diagram_options(request, options)

--- a/src/app/helpers/redmine_kroki_helper.rb
+++ b/src/app/helpers/redmine_kroki_helper.rb
@@ -89,9 +89,12 @@ module RedmineKrokiHelper
     end
   end
 
-  def generate_fa_css_tag(_diagram)
+  def generate_fa_css_tag(diagram)
+    return ''.html_safe unless diagram.include?('<i class="fa')
+
     fa_url = Setting.plugin_redmine_kroki[:fontawesome_css] ||
              Redmine::Plugin.find(:redmine_kroki).settings[:default]['fontawesome_css']
+
     stylesheet_link_tag fa_url
   end
 

--- a/src/app/views/settings/_redmine-kroki_settings.erb
+++ b/src/app/views/settings/_redmine-kroki_settings.erb
@@ -27,3 +27,10 @@
     </small>
   </p>
 </fieldset>
+<fieldset class="kroki-fieldset">
+  <legend class="kroki-legend">Mermaid</legend>
+  <span class="kroki-textfield">
+    <%= label_tag :settings_fontawesome_css, l('settings.display.fontawesome_css_url') %>
+    <%= text_field_tag "settings[fontawesome_css]", @settings["fontawesome_css"] || Redmine::Plugin.find(:redmine_kroki).settings[:default]['fontawesome_css'] %>
+  </span>
+</fieldset>

--- a/src/assets/stylesheets/redmine-kroki.css
+++ b/src/assets/stylesheets/redmine-kroki.css
@@ -40,7 +40,12 @@
   overflow: visible;
 }
 
-.kroki.mermaid foreignObject:has(.fa) {
+.kroki.mermaid foreignObject:has(.fa),
+.kroki.mermaid foreignObject:has(.fab),
+.kroki.mermaid foreignObject:has(.fad),
+.kroki.mermaid foreignObject:has(.fal),
+.kroki.mermaid foreignObject:has(.far),
+.kroki.mermaid foreignObject:has(.fas) {
   width: 100%;
   transform: translateX(-8px);
 }

--- a/src/assets/stylesheets/redmine-kroki.css
+++ b/src/assets/stylesheets/redmine-kroki.css
@@ -40,6 +40,11 @@
   overflow: visible;
 }
 
+.kroki.mermaid foreignObject:has(.fa) {
+  width: 100%;
+  transform: translateX(-8px);
+}
+
 /* Excalidraw */
 .kroki.excalidraw svg text {
   font-family: "Excalifont", sans-serif !important;

--- a/src/config/locales/ca.yml
+++ b/src/config/locales/ca.yml
@@ -18,3 +18,4 @@ ca:
       dark_theme_names_note: |
         Introdueix una llista separada per espais dels noms dels temes que
         requereixen text clar en un fons fosc.
+      fontawesome_css_url: 'URL del CSS de Font Awesome:'

--- a/src/config/locales/da.yml
+++ b/src/config/locales/da.yml
@@ -18,3 +18,4 @@ da:
       dark_theme_names_note: |
         Indtast en mellemrum adskilt liste af temanavne, der kræver lys tekst på
         mørk baggrund.
+      fontawesome_css_url: 'Font Awesome CSS URL:'

--- a/src/config/locales/de.yml
+++ b/src/config/locales/de.yml
@@ -18,3 +18,4 @@ de:
       dark_theme_names_note: |
         Geben Sie eine durch Leerzeichen getrennte Liste von Themennamen ein,
         die hellen Text auf dunklem Hintergrund erfordern.
+      fontawesome_css_url: 'Font Awesome CSS-URL:'

--- a/src/config/locales/en.yml
+++ b/src/config/locales/en.yml
@@ -18,3 +18,4 @@ en:
       dark_theme_names_note: |
         Enter a space separated list of theme names requiring light text on
         dark background.
+      fontawesome_css_url: 'Font Awesome CSS URL:'

--- a/src/config/locales/es.yml
+++ b/src/config/locales/es.yml
@@ -18,3 +18,4 @@ es:
       dark_theme_names_note: |
         Ingrese una lista separada por espacios de nombres de temas que
         requieran texto claro sobre fondo oscuro.
+      fontawesome_css_url: 'URL del CSS de Font Awesome:'

--- a/src/config/locales/fi.yml
+++ b/src/config/locales/fi.yml
@@ -17,3 +17,4 @@ fi:
       dark_theme_names_note: |
         Syötä välilyönnein erotettu luettelo teemanimistä, jotka vaativat
         vaalean tekstin tummalla taustalla.
+      fontawesome_css_url: 'Font Awesome CSS-URL:'

--- a/src/config/locales/fr.yml
+++ b/src/config/locales/fr.yml
@@ -18,3 +18,4 @@ fr:
       dark_theme_names_note: |
         Entrez une liste des noms de thèmes nécessitant un texte clair sur fond
         sombre, séparés par des espaces.
+      fontawesome_css_url: 'URL du CSS Font Awesome :'

--- a/src/config/locales/hi.yml
+++ b/src/config/locales/hi.yml
@@ -18,3 +18,4 @@ hi:
       dark_theme_names_note: |
         एक स्थान से अलग थीम नामों की सूची दर्ज करें जिनमें हल्का
         पाठ डार्क पृष्ठभूमि पर आवश्यक हो।
+      fontawesome_css_url: 'Font Awesome CSS का URL:'

--- a/src/config/locales/ja.yml
+++ b/src/config/locales/ja.yml
@@ -17,3 +17,4 @@ ja:
       dark_theme_names: 'ダークテーマ名：'
       dark_theme_names_note: |
         明るいテキストが必要なテーマ名のスペースで区切られたリストを入力してください。
+      fontawesome_css_url: 'Font Awesome の CSS URL：'

--- a/src/config/locales/pt.yml
+++ b/src/config/locales/pt.yml
@@ -18,3 +18,4 @@ pt:
       dark_theme_names_note: |
         Insira uma lista separada por espaços de nomes de temas que exigem texto
         claro em fundo escuro.
+      fontawesome_css_url: 'URL do CSS Font Awesome:'

--- a/src/config/locales/ru.yml
+++ b/src/config/locales/ru.yml
@@ -18,3 +18,4 @@ ru:
       dark_theme_names_note: |
         Введите список имен тем, разделенных пробелом, требующих светлого текста
         на темном фоне.
+      fontawesome_css_url: 'URL CSS-файла Font Awesome:'

--- a/src/config/locales/uk.yml
+++ b/src/config/locales/uk.yml
@@ -18,3 +18,4 @@ uk:
       dark_theme_names_note: |
         Введіть список назв тем, розділених пробілом, які потребують
         світлого тексту на темному фоні.
+      fontawesome_css_url: 'URL CSS-файлу Font Awesome:'

--- a/src/config/locales/zh.yml
+++ b/src/config/locales/zh.yml
@@ -16,3 +16,4 @@ zh:
       dark_theme_names: '深色主题名称：'
       dark_theme_names_note: |
         输入一个用空格分隔的主题名称列表，要求在深色背景上使用浅色文本。
+      fontawesome_css_url: 'Font Awesome CSS 地址：'

--- a/src/init.rb
+++ b/src/init.rb
@@ -12,7 +12,7 @@ Redmine::Plugin.register :redmine_kroki do
              'kroki_url' => 'http://kroki:8000',
              'dark_themes' => %w[dark dark-theme redmine-dark],
              'force_dark' => false,
-             'fontawesome_css' => 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css'
+             'fontawesome_css' => 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css'
            },
            partial: 'settings/redmine-kroki_settings'
 

--- a/src/init.rb
+++ b/src/init.rb
@@ -11,7 +11,8 @@ Redmine::Plugin.register :redmine_kroki do
   settings default: {
              'kroki_url' => 'http://kroki:8000',
              'dark_themes' => %w[dark dark-theme redmine-dark],
-             'force_dark' => false
+             'force_dark' => false,
+             'fontawesome_css' => 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css'
            },
            partial: 'settings/redmine-kroki_settings'
 

--- a/src/lib/mermaid_icon_patterns.rb
+++ b/src/lib/mermaid_icon_patterns.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# HACK: Kroki doesn't correctly size boxes with icons, but padding with
+# non-breaking spaces fixes most of it.
+module MermaidIconPatterns
+  PATTERNS = [
+  # Double circle - no text ((( fa:fa-icon )))  WARN: Must come before circle
+  {
+    regex: /(\(\(\()fa:([\w-]+)\s*(\)\)\))/,
+    replacement: '\1&nbsp;&nbsp; fa:\2 &nbsp;&nbsp;&nbsp;\3',
+  },
+  # Double circle - with text ((( fa:fa-icon Text )))  WARN: Must come before circle
+  {
+    regex: /(\(\(\()fa:([\w-]+)(\s+.*?)(\)\)\))/,
+    replacement: '\1&nbsp; fa:\2\3 &nbsp;&nbsp;&nbsp;\4',
+  },
+  # Circle - no text (( fa:fa-icon ))
+  {
+    regex: /(\(\()fa:([\w-]+)\s*(\)\))/,
+    replacement: '\1&nbsp;&nbsp; fa:\2 &nbsp;&nbsp;&nbsp;\3',
+  },
+  # Circle - with text (( fa:fa-icon Text ))
+  {
+    regex: /(\(\()fa:([\w-]+)(\s+.*?)(\)\))/,
+    replacement: '\1&nbsp; fa:\2\3 &nbsp;&nbsp;\4',
+  },
+  # Stadium shapes ([ fa:fa-icon (Text)? ])
+  {
+    regex: /(\(\[)fa:([\w-]+)(\s+.*?)?(\]\))/,
+    replacement: '\1&nbsp; fa:\2\3 &nbsp;\4',
+  },
+  # Subroutines shapes [[ fa:fa-icon (Text)? ]]
+  {
+    regex: /(\[\[)fa:([\w-]+)(\s+.*?)?(\]\])/,
+    replacement: '\1&nbsp; fa:\2\3 &nbsp;\4',
+  },
+  # Cylindrical shapes [( fa:fa-icon (Text)? )]
+  {
+    regex: /(\[\()fa:([\w-]+)(\s+.*?)?(\)\])/,
+    replacement: '\1&nbsp; fa:\2\3 &nbsp;\4',
+  },
+  # Hexagon shapes {{ fa:fa-icon (Text)? }}
+  {
+    regex: /(\{\{)fa:([\w-]+)(\s+.*?)?(\}\})/,
+    replacement: '\1&nbsp; fa:\2\3 &nbsp;\4',
+  },
+  # Parallelogram [/ fa:fa-icon (Text)? /]
+  {
+    regex: /(\[\/)fa:([\w-]+)(\s+.*?)?(\/\])/,
+    replacement: '\1&nbsp; fa:\2\3\4',
+  },
+  # Parallelogram [\ fa:fa-icon (Text)? \]
+  {
+    regex: /(\[\\)fa:([\w-]+)(\s+.*?)?(\\\])/,
+    replacement: '\1&nbsp; fa:\2\3 &nbsp;\4',
+  },
+  # Trapezoid [/ fa:fa-icon (Text)? \]
+  {
+    regex: /(\[\/)fa:([\w-]+)(\s+.*?)?(\\\])/,
+    replacement: '\1&nbsp; fa:\2\3 &nbsp;\4',
+  },
+  # Trapezoid [\ fa:fa-icon (Text)? /]
+  {
+    regex: /(\[\\)fa:([\w-]+)(\s+.*?)?(\/\])/,
+    replacement: '\1&nbsp; fa:\2\3 &nbsp;\4',
+  },
+  # Asymmetrical shapes >fa:icon (Text)?]
+  {
+    regex: /(>)fa:([\w-]+)(\s+.*?)?(\])/,
+    replacement: '\1&nbsp; fa:\2\3&nbsp;&nbsp;\4',
+  },
+  # Simple shapes with no text  WARN: Must be last!
+  {
+    regex: /([(\[{])fa:([\w-]+)\s*([)\]}])/,
+    replacement: '\1&nbsp; fa:\2 &nbsp;\3',
+  }
+  ].freeze
+end
+
+MERMAID_SHAPE_ICON_PATTERNS = MermaidIconPatterns::PATTERNS

--- a/src/lib/mermaid_icon_patterns.rb
+++ b/src/lib/mermaid_icon_patterns.rb
@@ -7,7 +7,7 @@ module MermaidIconPatterns
   # Double circle - no text ((( fa:fa-icon )))  WARN: Must come before circle
   {
     regex: /(\(\(\()fa:([\w-]+)\s*(\)\)\))/,
-    replacement: '\1&nbsp;&nbsp; fa:\2 &nbsp;&nbsp;&nbsp;\3',
+    replacement: '\1&nbsp; fa:\2 &nbsp;&nbsp;&nbsp;\3',
   },
   # Double circle - with text ((( fa:fa-icon Text )))  WARN: Must come before circle
   {
@@ -17,61 +17,71 @@ module MermaidIconPatterns
   # Circle - no text (( fa:fa-icon ))
   {
     regex: /(\(\()fa:([\w-]+)\s*(\)\))/,
-    replacement: '\1&nbsp;&nbsp; fa:\2 &nbsp;&nbsp;&nbsp;\3',
+    replacement: '\1&nbsp;&nbsp; fa:\2 &nbsp;&nbsp;&nbsp;&nbsp;\3',
   },
   # Circle - with text (( fa:fa-icon Text ))
   {
     regex: /(\(\()fa:([\w-]+)(\s+.*?)(\)\))/,
-    replacement: '\1&nbsp; fa:\2\3 &nbsp;&nbsp;\4',
+    replacement: '\1&nbsp; fa:\2\3 &nbsp;&nbsp;&nbsp;\4',
   },
   # Stadium shapes ([ fa:fa-icon (Text)? ])
   {
     regex: /(\(\[)fa:([\w-]+)(\s+.*?)?(\]\))/,
-    replacement: '\1&nbsp; fa:\2\3 &nbsp;\4',
+    replacement: '\1&nbsp; fa:\2\3 &nbsp;&nbsp;\4',
   },
-  # Subroutines shapes [[ fa:fa-icon (Text)? ]]
+  # Subroutine shapes [[ fa:fa-icon (Text)? ]]
   {
     regex: /(\[\[)fa:([\w-]+)(\s+.*?)?(\]\])/,
-    replacement: '\1&nbsp; fa:\2\3 &nbsp;\4',
+    replacement: '\1&nbsp; fa:\2\3 &nbsp;&nbsp;&nbsp;\4',
   },
   # Cylindrical shapes [( fa:fa-icon (Text)? )]
   {
     regex: /(\[\()fa:([\w-]+)(\s+.*?)?(\)\])/,
-    replacement: '\1&nbsp; fa:\2\3 &nbsp;\4',
+    replacement: '\1&nbsp; fa:\2\3 &nbsp;&nbsp;&nbsp;\4',
   },
   # Hexagon shapes {{ fa:fa-icon (Text)? }}
   {
     regex: /(\{\{)fa:([\w-]+)(\s+.*?)?(\}\})/,
-    replacement: '\1&nbsp; fa:\2\3 &nbsp;\4',
+    replacement: '\1&nbsp;fa:\2\3&nbsp;&nbsp;\4',
   },
   # Parallelogram [/ fa:fa-icon (Text)? /]
   {
     regex: /(\[\/)fa:([\w-]+)(\s+.*?)?(\/\])/,
-    replacement: '\1&nbsp; fa:\2\3\4',
+    replacement: '\1&nbsp;fa:\2\3 &nbsp;\4',
   },
   # Parallelogram [\ fa:fa-icon (Text)? \]
   {
     regex: /(\[\\)fa:([\w-]+)(\s+.*?)?(\\\])/,
-    replacement: '\1&nbsp; fa:\2\3 &nbsp;\4',
+    replacement: '\1&nbsp; fa:\2\3 &nbsp;&nbsp;\4',
   },
   # Trapezoid [/ fa:fa-icon (Text)? \]
   {
     regex: /(\[\/)fa:([\w-]+)(\s+.*?)?(\\\])/,
-    replacement: '\1&nbsp; fa:\2\3 &nbsp;\4',
+    replacement: '\1&nbsp; fa:\2\3 &nbsp;&nbsp;\4',
   },
   # Trapezoid [\ fa:fa-icon (Text)? /]
   {
     regex: /(\[\\)fa:([\w-]+)(\s+.*?)?(\/\])/,
-    replacement: '\1&nbsp; fa:\2\3 &nbsp;\4',
+    replacement: '\1fa:\2\3 &nbsp;\4',
   },
   # Asymmetrical shapes >fa:icon (Text)?]
   {
     regex: /(>)fa:([\w-]+)(\s+.*?)?(\])/,
-    replacement: '\1&nbsp; fa:\2\3&nbsp;&nbsp;\4',
+    replacement: '\1&nbsp;&nbsp;fa:\2\3&nbsp;&nbsp;&nbsp;\4',
+  },
+  # Rhombus shapes - no text { fa:fa-icon }
+  {
+    regex: /(\{)fa:([\w-]+)(\s+)?(\})/,
+    replacement: '\1&nbsp;&nbsp;fa:\2\3 &nbsp;\4',
+  },
+  # Rhombus shapes { fa:fa-icon Text }
+  {
+    regex: /(\{)fa:([\w-]+)(\s+.*?)(\})/,
+    replacement: '\1fa:\2\3 &nbsp;&nbsp;\4',
   },
   # Simple shapes with no text  WARN: Must be last!
   {
-    regex: /([(\[{])fa:([\w-]+)\s*([)\]}])/,
+    regex: /([(\[])fa:([\w-]+)\s*([)\]])/,
     replacement: '\1&nbsp; fa:\2 &nbsp;\3',
   }
   ].freeze

--- a/src/test/redmine_kroki_helper.rb
+++ b/src/test/redmine_kroki_helper.rb
@@ -666,4 +666,16 @@ Ref: posts.user_id > users.id // many-to-one')
     result = sanitize_diagram('mermaid', nil)
     assert_nil(result)
   end
+
+  test 'sanitize_diagram fixes missing word after FontAwesome icon in mermaid with arrow' do
+    input = 'flowchart LR; A>fa:fa-check]'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A>&nbsp; fa:fa-check&nbsp;]', result)
+  end
+
+  test 'sanitize_diagram handles FontAwesome icon with text in arrow shape' do
+    input = 'flowchart LR; A>fa:fa-check Done]'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A>&nbsp; fa:fa-check Done&nbsp;]', result)
+  end
 end

--- a/src/test/redmine_kroki_helper.rb
+++ b/src/test/redmine_kroki_helper.rb
@@ -670,19 +670,19 @@ Ref: posts.user_id > users.id // many-to-one')
   test 'sanitize_diagram fixes missing word after FontAwesome icon in mermaid with arrow' do
     input = 'flowchart LR; A>fa:fa-check]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A>&nbsp; fa:fa-check&nbsp;&nbsp;]', result)
+    assert_equal('flowchart LR; A>&nbsp;&nbsp;fa:fa-check&nbsp;&nbsp;&nbsp;]', result)
   end
 
   test 'sanitize_diagram handles FontAwesome icon with text in arrow shape' do
     input = 'flowchart LR; A>fa:fa-check Done]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A>&nbsp; fa:fa-check Done&nbsp;&nbsp;]', result)
+    assert_equal('flowchart LR; A>&nbsp;&nbsp;fa:fa-check Done&nbsp;&nbsp;&nbsp;]', result)
   end
 
   test 'sanitize_diagram handles double circle with no text' do
     input = 'flowchart LR; A(((fa:fa-user)))'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A(((&nbsp;&nbsp; fa:fa-user &nbsp;&nbsp;&nbsp;)))', result)
+    assert_equal('flowchart LR; A(((&nbsp; fa:fa-user &nbsp;&nbsp;&nbsp;)))', result)
   end
 
   test 'sanitize_diagram handles double circle with text' do
@@ -694,132 +694,132 @@ Ref: posts.user_id > users.id // many-to-one')
   test 'sanitize_diagram handles circle with no text' do
     input = 'flowchart LR; A((fa:fa-user))'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A((&nbsp;&nbsp; fa:fa-user &nbsp;&nbsp;&nbsp;))', result)
+    assert_equal('flowchart LR; A((&nbsp;&nbsp; fa:fa-user &nbsp;&nbsp;&nbsp;&nbsp;))', result)
   end
 
   test 'sanitize_diagram handles circle with text' do
     input = 'flowchart LR; A((fa:fa-user User))'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A((&nbsp; fa:fa-user User &nbsp;&nbsp;))', result)
+    assert_equal('flowchart LR; A((&nbsp; fa:fa-user User &nbsp;&nbsp;&nbsp;))', result)
   end
 
   test 'sanitize_diagram handles stadium shape with no text' do
     input = 'flowchart LR; A([fa:fa-database])'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A([&nbsp; fa:fa-database &nbsp;])', result)
+    assert_equal('flowchart LR; A([&nbsp; fa:fa-database &nbsp;&nbsp;])', result)
   end
 
   test 'sanitize_diagram handles stadium shape with text' do
     input = 'flowchart LR; A([fa:fa-database Database])'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A([&nbsp; fa:fa-database Database &nbsp;])', result)
+    assert_equal('flowchart LR; A([&nbsp; fa:fa-database Database &nbsp;&nbsp;])', result)
   end
 
   test 'sanitize_diagram handles subroutine shape with no text' do
     input = 'flowchart LR; A[[fa:fa-cog]]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A[[&nbsp; fa:fa-cog &nbsp;]]', result)
+    assert_equal('flowchart LR; A[[&nbsp; fa:fa-cog &nbsp;&nbsp;&nbsp;]]', result)
   end
 
   test 'sanitize_diagram handles subroutine shape with text' do
     input = 'flowchart LR; A[[fa:fa-cog Process]]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A[[&nbsp; fa:fa-cog Process &nbsp;]]', result)
+    assert_equal('flowchart LR; A[[&nbsp; fa:fa-cog Process &nbsp;&nbsp;&nbsp;]]', result)
   end
 
   test 'sanitize_diagram handles cylindrical shape with no text' do
     input = 'flowchart LR; A[(fa:fa-hdd)]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A[(&nbsp; fa:fa-hdd &nbsp;)]', result)
+    assert_equal('flowchart LR; A[(&nbsp; fa:fa-hdd &nbsp;&nbsp;&nbsp;)]', result)
   end
 
   test 'sanitize_diagram handles cylindrical shape with text' do
     input = 'flowchart LR; A[(fa:fa-hdd Storage)]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A[(&nbsp; fa:fa-hdd Storage &nbsp;)]', result)
+    assert_equal('flowchart LR; A[(&nbsp; fa:fa-hdd Storage &nbsp;&nbsp;&nbsp;)]', result)
   end
 
   test 'sanitize_diagram handles hexagon shape with no text' do
     input = 'flowchart LR; A{{fa:fa-code}}'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A{{&nbsp; fa:fa-code &nbsp;}}', result)
+    assert_equal('flowchart LR; A{{&nbsp;fa:fa-code&nbsp;&nbsp;}}', result)
   end
 
   test 'sanitize_diagram handles hexagon shape with text' do
     input = 'flowchart LR; A{{fa:fa-code Function}}'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A{{&nbsp; fa:fa-code Function &nbsp;}}', result)
+    assert_equal('flowchart LR; A{{&nbsp;fa:fa-code Function&nbsp;&nbsp;}}', result)
   end
 
   test 'sanitize_diagram handles parallelogram shape type 1 with no text' do
     input = 'flowchart LR; A[/fa:fa-file/]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A[/&nbsp; fa:fa-file/]', result)
+    assert_equal('flowchart LR; A[/&nbsp;fa:fa-file &nbsp;/]', result)
   end
 
   test 'sanitize_diagram handles parallelogram shape type 1 with text' do
     input = 'flowchart LR; A[/fa:fa-file Input/]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A[/&nbsp; fa:fa-file Input/]', result)
+    assert_equal('flowchart LR; A[/&nbsp;fa:fa-file Input &nbsp;/]', result)
   end
 
   test 'sanitize_diagram handles parallelogram shape type 2 with no text' do
     input = 'flowchart LR; A[\\fa:fa-file\\]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A[\\&nbsp; fa:fa-file &nbsp;\\]', result)
+    assert_equal('flowchart LR; A[\\&nbsp; fa:fa-file &nbsp;&nbsp;\\]', result)
   end
 
   test 'sanitize_diagram handles parallelogram shape type 2 with text' do
     input = 'flowchart LR; A[\\fa:fa-file Output\\]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A[\\&nbsp; fa:fa-file Output &nbsp;\\]', result)
+    assert_equal('flowchart LR; A[\\&nbsp; fa:fa-file Output &nbsp;&nbsp;\\]', result)
   end
 
   test 'sanitize_diagram handles trapezoid shape type 1 with no text' do
     input = 'flowchart LR; A[/fa:fa-bolt\\]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A[/&nbsp; fa:fa-bolt &nbsp;\\]', result)
+    assert_equal('flowchart LR; A[/&nbsp; fa:fa-bolt &nbsp;&nbsp;\\]', result)
   end
 
   test 'sanitize_diagram handles trapezoid shape type 1 with text' do
     input = 'flowchart LR; A[/fa:fa-bolt Action\\]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A[/&nbsp; fa:fa-bolt Action &nbsp;\\]', result)
+    assert_equal('flowchart LR; A[/&nbsp; fa:fa-bolt Action &nbsp;&nbsp;\\]', result)
   end
 
   test 'sanitize_diagram handles trapezoid shape type 2 with no text' do
     input = 'flowchart LR; A[\\fa:fa-warning/]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A[\\&nbsp; fa:fa-warning &nbsp;/]', result)
+    assert_equal('flowchart LR; A[\\fa:fa-warning &nbsp;/]', result)
   end
 
   test 'sanitize_diagram handles trapezoid shape type 2 with text' do
     input = 'flowchart LR; A[\\fa:fa-warning Alert/]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A[\\&nbsp; fa:fa-warning Alert &nbsp;/]', result)
+    assert_equal('flowchart LR; A[\\fa:fa-warning Alert &nbsp;/]', result)
   end
 
   test 'sanitize_diagram handles asymmetrical flag shape with no text' do
     input = 'flowchart LR; A>fa:fa-flag]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A>&nbsp; fa:fa-flag&nbsp;&nbsp;]', result)
+    assert_equal('flowchart LR; A>&nbsp;&nbsp;fa:fa-flag&nbsp;&nbsp;&nbsp;]', result)
   end
 
   test 'sanitize_diagram handles asymmetrical flag shape with text' do
     input = 'flowchart LR; A>fa:fa-flag Flag]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A>&nbsp; fa:fa-flag Flag&nbsp;&nbsp;]', result)
+    assert_equal('flowchart LR; A>&nbsp;&nbsp;fa:fa-flag Flag&nbsp;&nbsp;&nbsp;]', result)
   end
 
   test 'sanitize_diagram handles curly brace diamond shape with no text' do
     input = 'flowchart LR; A{fa:fa-question}'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A{&nbsp; fa:fa-question &nbsp;}', result)
+    assert_equal('flowchart LR; A{&nbsp;&nbsp;fa:fa-question &nbsp;}', result)
   end
 
-  test 'sanitize_diagram does not pad curly brace diamond shape with text' do
+  test 'sanitize_diagram handles curly brace diamond shape with text' do
     input = 'flowchart LR; A{fa:fa-question Decision}'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A{fa:fa-question Decision}', result)
+    assert_equal('flowchart LR; A{fa:fa-question Decision &nbsp;&nbsp;}', result)
   end
 end

--- a/src/test/redmine_kroki_helper.rb
+++ b/src/test/redmine_kroki_helper.rb
@@ -670,12 +670,156 @@ Ref: posts.user_id > users.id // many-to-one')
   test 'sanitize_diagram fixes missing word after FontAwesome icon in mermaid with arrow' do
     input = 'flowchart LR; A>fa:fa-check]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A>&nbsp; fa:fa-check&nbsp;]', result)
+    assert_equal('flowchart LR; A>&nbsp; fa:fa-check&nbsp;&nbsp;]', result)
   end
 
   test 'sanitize_diagram handles FontAwesome icon with text in arrow shape' do
     input = 'flowchart LR; A>fa:fa-check Done]'
     result = sanitize_diagram('mermaid', input)
-    assert_equal('flowchart LR; A>&nbsp; fa:fa-check Done&nbsp;]', result)
+    assert_equal('flowchart LR; A>&nbsp; fa:fa-check Done&nbsp;&nbsp;]', result)
+  end
+
+  test 'sanitize_diagram handles double circle with no text' do
+    input = 'flowchart LR; A(((fa:fa-user)))'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A(((&nbsp;&nbsp; fa:fa-user &nbsp;&nbsp;&nbsp;)))', result)
+  end
+
+  test 'sanitize_diagram handles double circle with text' do
+    input = 'flowchart LR; A(((fa:fa-user User)))'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A(((&nbsp; fa:fa-user User &nbsp;&nbsp;&nbsp;)))', result)
+  end
+
+  test 'sanitize_diagram handles circle with no text' do
+    input = 'flowchart LR; A((fa:fa-user))'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A((&nbsp;&nbsp; fa:fa-user &nbsp;&nbsp;&nbsp;))', result)
+  end
+
+  test 'sanitize_diagram handles circle with text' do
+    input = 'flowchart LR; A((fa:fa-user User))'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A((&nbsp; fa:fa-user User &nbsp;&nbsp;))', result)
+  end
+
+  test 'sanitize_diagram handles stadium shape with no text' do
+    input = 'flowchart LR; A([fa:fa-database])'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A([&nbsp; fa:fa-database &nbsp;])', result)
+  end
+
+  test 'sanitize_diagram handles stadium shape with text' do
+    input = 'flowchart LR; A([fa:fa-database Database])'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A([&nbsp; fa:fa-database Database &nbsp;])', result)
+  end
+
+  test 'sanitize_diagram handles subroutine shape with no text' do
+    input = 'flowchart LR; A[[fa:fa-cog]]'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A[[&nbsp; fa:fa-cog &nbsp;]]', result)
+  end
+
+  test 'sanitize_diagram handles subroutine shape with text' do
+    input = 'flowchart LR; A[[fa:fa-cog Process]]'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A[[&nbsp; fa:fa-cog Process &nbsp;]]', result)
+  end
+
+  test 'sanitize_diagram handles cylindrical shape with no text' do
+    input = 'flowchart LR; A[(fa:fa-hdd)]'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A[(&nbsp; fa:fa-hdd &nbsp;)]', result)
+  end
+
+  test 'sanitize_diagram handles cylindrical shape with text' do
+    input = 'flowchart LR; A[(fa:fa-hdd Storage)]'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A[(&nbsp; fa:fa-hdd Storage &nbsp;)]', result)
+  end
+
+  test 'sanitize_diagram handles hexagon shape with no text' do
+    input = 'flowchart LR; A{{fa:fa-code}}'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A{{&nbsp; fa:fa-code &nbsp;}}', result)
+  end
+
+  test 'sanitize_diagram handles hexagon shape with text' do
+    input = 'flowchart LR; A{{fa:fa-code Function}}'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A{{&nbsp; fa:fa-code Function &nbsp;}}', result)
+  end
+
+  test 'sanitize_diagram handles parallelogram shape type 1 with no text' do
+    input = 'flowchart LR; A[/fa:fa-file/]'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A[/&nbsp; fa:fa-file/]', result)
+  end
+
+  test 'sanitize_diagram handles parallelogram shape type 1 with text' do
+    input = 'flowchart LR; A[/fa:fa-file Input/]'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A[/&nbsp; fa:fa-file Input/]', result)
+  end
+
+  test 'sanitize_diagram handles parallelogram shape type 2 with no text' do
+    input = 'flowchart LR; A[\\fa:fa-file\\]'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A[\\&nbsp; fa:fa-file &nbsp;\\]', result)
+  end
+
+  test 'sanitize_diagram handles parallelogram shape type 2 with text' do
+    input = 'flowchart LR; A[\\fa:fa-file Output\\]'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A[\\&nbsp; fa:fa-file Output &nbsp;\\]', result)
+  end
+
+  test 'sanitize_diagram handles trapezoid shape type 1 with no text' do
+    input = 'flowchart LR; A[/fa:fa-bolt\\]'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A[/&nbsp; fa:fa-bolt &nbsp;\\]', result)
+  end
+
+  test 'sanitize_diagram handles trapezoid shape type 1 with text' do
+    input = 'flowchart LR; A[/fa:fa-bolt Action\\]'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A[/&nbsp; fa:fa-bolt Action &nbsp;\\]', result)
+  end
+
+  test 'sanitize_diagram handles trapezoid shape type 2 with no text' do
+    input = 'flowchart LR; A[\\fa:fa-warning/]'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A[\\&nbsp; fa:fa-warning &nbsp;/]', result)
+  end
+
+  test 'sanitize_diagram handles trapezoid shape type 2 with text' do
+    input = 'flowchart LR; A[\\fa:fa-warning Alert/]'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A[\\&nbsp; fa:fa-warning Alert &nbsp;/]', result)
+  end
+
+  test 'sanitize_diagram handles asymmetrical flag shape with no text' do
+    input = 'flowchart LR; A>fa:fa-flag]'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A>&nbsp; fa:fa-flag&nbsp;&nbsp;]', result)
+  end
+
+  test 'sanitize_diagram handles asymmetrical flag shape with text' do
+    input = 'flowchart LR; A>fa:fa-flag Flag]'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A>&nbsp; fa:fa-flag Flag&nbsp;&nbsp;]', result)
+  end
+
+  test 'sanitize_diagram handles curly brace diamond shape with no text' do
+    input = 'flowchart LR; A{fa:fa-question}'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A{&nbsp; fa:fa-question &nbsp;}', result)
+  end
+
+  test 'sanitize_diagram does not pad curly brace diamond shape with text' do
+    input = 'flowchart LR; A{fa:fa-question Decision}'
+    result = sanitize_diagram('mermaid', input)
+    assert_equal('flowchart LR; A{fa:fa-question Decision}', result)
   end
 end

--- a/src/test/redmine_kroki_helper.rb
+++ b/src/test/redmine_kroki_helper.rb
@@ -562,38 +562,54 @@ Ref: posts.user_id > users.id // many-to-one')
   end
 
   test 'embed_fonts returns excalidraw.css for excalidraw' do
-    result = embed_fonts('excalidraw')
+    result = embed_fonts('excalidraw', 'diagram content')
     assert_match(/\<link rel="stylesheet"/, result)
     assert_match(/\/excalidraw\.css/, result)
   end
 
+  test 'embed_fonts returns Font Awesome CSS for mermaid' do
+    result = embed_fonts('mermaid', 'flowchart LR; a --> b')
+    assert_match(/\<link rel="stylesheet"/, result)
+  end
+
   test 'embed_fonts returns empty string for other diagram types' do
-    result = embed_fonts('mermaid')
+    result = embed_fonts('plantuml', 'a -> b')
     assert_equal('', result)
 
-    result = embed_fonts('plantuml')
+    result = embed_fonts('graphviz', 'digraph G {a->b}')
     assert_equal('', result)
 
-    result = embed_fonts('graphviz')
+    result = embed_fonts('blockdiag', 'blockdiag {a -> b}')
     assert_equal('', result)
   end
 
   test 'embed_fonts returns empty string for nil or empty diagram type' do
-    result = embed_fonts(nil)
+    result = embed_fonts(nil, 'diagram content')
     assert_equal('', result)
 
-    result = embed_fonts('')
+    result = embed_fonts('', 'diagram content')
     assert_equal('', result)
   end
 
   test 'embed_fonts is case insensitive for excalidraw' do
-    result = embed_fonts('Excalidraw')
+    result = embed_fonts('Excalidraw', 'diagram content')
     assert_match(/excalidraw/, result)
 
-    result = embed_fonts('EXCALIDRAW')
+    result = embed_fonts('EXCALIDRAW', 'diagram content')
     assert_match(/excalidraw/, result)
 
-    result = embed_fonts('ExCaLiDrAw')
+    result = embed_fonts('ExCaLiDrAw', 'diagram content')
     assert_match(/excalidraw/, result)
+  end
+
+  test 'embed_fonts is case insensitive for mermaid' do
+    result = embed_fonts('Mermaid', 'flowchart LR; a --> b')
+    assert_match(/\<link rel="stylesheet"/, result)
+
+    result = embed_fonts('MERMAID', 'flowchart LR; a --> b')
+    assert_match(/\<link rel="stylesheet"/, result)
+
+    result = embed_fonts('MeRmAiD', 'flowchart LR; a --> b')
+    assert_match(/\<link rel="stylesheet"/, result)
   end
 end


### PR DESCRIPTION
Adding this feature since MermaidJS support adding Font Awesome icons to diagrams.

I've tested few diagrams sample and icons and ~~the most compatible version of Font Awesome is 4.7.0. This is the default,~~ implemented Font Awesome v7.0.1 as the default, but I added an option in the settings in case somebody would want to change it to another version.

Supported icon name prefixes: `fa`, `fab`, `fas`, `far`, `fal`, `fad`.

Can be tested with:
```
{{kroki(mermaid)
flowchart TD
A[fa:fa-star Start] --> B[fa:fa-circle End]
}}
```

<img width="133" height="213" alt="image" src="https://github.com/user-attachments/assets/75870b28-3cad-46ef-8c6d-2939c3152a1d" />
<img width="138" height="218" alt="image" src="https://github.com/user-attachments/assets/f49615bf-016b-4fc6-9fd0-007bc7d24cd3" />


## Todo

- [x] Font is loading and displayed
- [x] Icons are displaying correctly
  - [x] In rectangular boxes
  - [x] In rounded corner boxes
  - [x] In decision boxes
- [x] Icons without text are displaying correctly
  - [x] In regular boxes
  - [x] In rounded corner boxes
  - [x] In decision boxes   
- [x] Dark theme support

## Documentation

* [MermaidJs - Basic Support for fontawesome](https://mermaid.js.org/syntax/flowchart.html#basic-support-for-fontawesome)
